### PR TITLE
Exceptions throw with current client type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/mono-client",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Soap and rest connector",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -101,7 +101,7 @@ export class MonoClient<
     if (attempt + 1 < maxAttempt && this.shouldRetry(request, response)) {
       return this.requestAttempt({ request, maxAttempt, attempt: attempt + 1 });
     }
-    throw new RequestFail(request, response);
+    throw new RequestFail(this.config.type, request, response);
   }
 
   async request<T>(params: R): Promise<TemplateResponse<T>> {

--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -13,7 +13,11 @@ export class MissingPathParameter extends Error {
 }
 
 export class RequestFail extends Error {
-  constructor(public request: MonoClientRequest, public response: MonoClientResponse) {
+  constructor(
+    public type: 'soap' | 'rest',
+    public request: MonoClientRequest,
+    public response: MonoClientResponse
+  ) {
     super(
       `Request Fail - ${response.statusCode} - ${
         JSON.stringify(response.body) || response.message || 'unknown error'


### PR DESCRIPTION
We need to know the error type to correctly access error.request props