### PR TITLE
Feat: Adding body parser option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - Metrics and starts date always available
 - Reuse configuration for business units and services
 - TypeScript Support
+- body parser 
 
 ## Installing
 
@@ -126,6 +127,10 @@ async function testSoap() {
         // This will overwrite retry on and notOn
         return response.body.Error === 'server timeout';
       }
+    },
+    bodyParser<T>(body: any): T {
+      //Is optional, returns any pardes property as response body
+      return JSON.parse(body.clientData);
     }
   });
   const response = await soapClient.request({
@@ -186,6 +191,10 @@ async function restTest() {
         // This will overwrite retry on and notOn
         return response.body.Error === 'server timeout';
       }
+    },
+    bodyParser<T>(body: any): T {
+      //Is optional, returns any pardes property as response body
+      return JSON.parse(body.clientData);
     }
   });
 
@@ -231,6 +240,9 @@ async function generatorTest() {
       console.log(response);
       console.log(info);
     },
+    bodyParser<T>(body: any): T {
+      //Is optional, returns any pardes property as response body
+      return JSON.parse(body.clientData);
   });
 
   const restClient = generator.get({

--- a/src/client/__tests__/body-parser.test.ts
+++ b/src/client/__tests__/body-parser.test.ts
@@ -1,0 +1,67 @@
+import axios from 'axios';
+import { MonoClient } from '..';
+
+const CLIENT_DATA = {
+  client: 'aaa'
+};
+
+const RESPONSE_DATA = {
+  clientData: JSON.stringify(CLIENT_DATA)
+};
+
+describe('Body parser functionality', () => {
+  describe('Send body parser to client', () => {
+    it('Should parse data', async () => {
+      jest.spyOn(axios, 'request').mockImplementation(() => {
+        return new Promise((resolve) => {
+          resolve({
+            data: RESPONSE_DATA,
+            headers: {},
+            status: 200
+          });
+        });
+      });
+      const client = new MonoClient({
+        type: 'rest',
+        baseUrl: 'www.test.com',
+        bodyParser<T>(body: any): T {
+          return JSON.parse(body.clientData);
+        }
+      });
+      const data = await client.request<any>({
+        path: '/public/v1/users',
+        method: 'POST'
+      });
+
+      expect(data.body).toStrictEqual(CLIENT_DATA);
+      jest.restoreAllMocks();
+    });
+  });
+  describe('Send body parser to request', () => {
+    it('Should parse data', async () => {
+      jest.spyOn(axios, 'request').mockImplementation(() => {
+        return new Promise((resolve) => {
+          resolve({
+            data: RESPONSE_DATA,
+            headers: {},
+            status: 200
+          });
+        });
+      });
+      const client = new MonoClient({
+        type: 'rest',
+        baseUrl: 'www.test.com'
+      });
+      const data = await client.request<any>({
+        path: '/public/v1/users',
+        method: 'POST',
+        bodyParser<T>(body: any): T {
+          return JSON.parse(body.clientData);
+        }
+      });
+
+      expect(data.body).toStrictEqual(CLIENT_DATA);
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -23,6 +23,17 @@ export class RequestFail extends Error {
   }
 }
 
+export class BodyParserFail extends Error {
+  constructor(
+    public type: 'soap' | 'rest',
+    public request: MonoClientRequest,
+    public response: MonoClientResponse,
+    public error: Error
+  ) {
+    super(`Body Parser - ${error.message}`);
+  }
+}
+
 export class ClientBadConfiguration extends Error {
   constructor(message: string) {
     super(message);

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -59,6 +59,7 @@ interface BaseRequest {
   isSuccessfulCallback?: IsSuccessfulCallback<Error>;
   shouldRetryCallback?: shouldRetryCallback;
   callback?: Callback;
+  bodyParser?: BodyParser;
 }
 
 export interface SoapRequest extends BaseRequest {
@@ -122,10 +123,13 @@ export type Callback = (
   info: Info
 ) => Promise<void> | void;
 
+export type BodyParser = (body: any) => any;
+
 interface MCBaseClientConfig {
   retry?: Retry;
   isSuccessfulCallback?: IsSuccessfulCallback<Error>;
   ssl?: SSL;
+  bodyParser?: BodyParser;
 }
 
 export interface SslSecurity {


### PR DESCRIPTION
Co-authored-by: rcabralyu <rodrigocabralyu@gmail.com>

## Ticket
[NOTION](https://www.notion.so/comparaonline/RPA-I-Sprint-3f61eb7b15784bdc8ea53db9996537d8?p=5307b1d76aa24f1eb21362b64138bd83)

## Purpose
> Add method for parse data in the response by monoclient

## Solution Approach
> add method to pass the object we need and return it as the response body
